### PR TITLE
Upgrade to latest, official OCF release of knative

### DIFF
--- a/knative/install.sh
+++ b/knative/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-set -x
+set -ex
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 REPO="$DIR/.repo"
 rm -rf "$REPO"
 git clone https://github.com/openshift-cloud-functions/knative-operators "$REPO"
-pushd $REPO; git checkout c749043 2>/dev/null; popd
+pushd $REPO; git checkout openshift-v0.3.0 2>/dev/null; popd
 "$REPO/etc/scripts/install.sh" -q


### PR DESCRIPTION
This uses our official 0.3.0 images from quay.io and includes some fixes to a few minor-but-annoying bugs, e.g. slow termination of pods.