### PR TITLE
Added patching the KafkaSource deployments for CPU and memory resources

### DIFF
--- a/syndesis/deploy.sh
+++ b/syndesis/deploy.sh
@@ -17,4 +17,5 @@ oc new-project ${TARGET_PROJECT} | true
 bash $dir/deploy_camel_k.sh ${TARGET_PROJECT}
 bash $dir/deploy_syndesis.sh ${TARGET_PROJECT}
 bash $dir/deploy_sources.sh ${TARGET_PROJECT}
+bash $dir/patch_sources_deployment.sh ${TARGET_PROJECT}
 bash $dir/deploy_services.sh ${TARGET_PROJECT}

--- a/syndesis/patch_sources_deployment.sh
+++ b/syndesis/patch_sources_deployment.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+TARGET_PROJECT=${1:-syndesis}
+
+# KafkaSource for hard share from sensorstream-raw topic
+KAFKA_SOURCE=$(oc get deployment -n $TARGET_PROJECT -l knative-eventing-source-name=sensorstream-source-raw -o jsonpath='{.items[0].metadata.name}{"\n"}')
+# check that the deployment is ready from the installation
+echo "Checking that $KAFKA_SOURCE deployment is ready..."
+oc rollout status deployment/$KAFKA_SOURCE -w -n $TARGET_PROJECT
+echo "...$KAFKA_SOURCE deployment ready"
+
+# patching and waiting for the related pod running
+oc patch deployment $KAFKA_SOURCE --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/resources", "value": {"requests": {"memory": "512Mi", "cpu": "250m"}, "limits": {"memory": "512Mi", "cpu": "250m"}}}]' -n $TARGET_PROJECT
+
+echo "Waiting for $KAFKA_SOURCE deployment to be ready..."
+oc rollout status deployment/$KAFKA_SOURCE -w -n $TARGET_PROJECT
+echo "...$KAFKA_SOURCE deployment ready"
+
+# KafkaSource for the game from sensorstream-ai topic
+KAFKA_SOURCE=$(oc get deployment -n $TARGET_PROJECT -l knative-eventing-source-name=sensorstream-source -o jsonpath='{.items[0].metadata.name}{"\n"}')
+# check that the deployment is ready from the installation
+echo "Checking that $KAFKA_SOURCE deployment is ready..."
+oc rollout status deployment/$KAFKA_SOURCE -w -n $TARGET_PROJECT
+echo "...$KAFKA_SOURCE deployment ready"
+
+# patching and waiting for the related pod running
+oc patch deployment $KAFKA_SOURCE --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/resources", "value": {"requests": {"memory": "512Mi", "cpu": "250m"}, "limits": {"memory": "512Mi", "cpu": "250m"}}}]' -n $TARGET_PROJECT
+
+echo "Waiting for $KAFKA_SOURCE deployment to be ready..."
+oc rollout status deployment/$KAFKA_SOURCE -w -n $TARGET_PROJECT
+echo "...$KAFKA_SOURCE deployment ready"


### PR DESCRIPTION
Talking with @matzew , it's not possible to specify CPU and memory requests/limits on Knative `KafkaSource` resources and the only way is to patch the related `Deployment`(s).
For this reason, I am proposing this PR where after deploying the sources, a shell script is executed for getting the related `Deployment`(s) and patching them for setting resources requests/limits.